### PR TITLE
add shortcutsbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Middleware for LLMs: Tools Are Instrumental for Language Agents in Complex Envir
 Equipping Language Models with Tool Use Capability for Tabular Data Analysis in Finance [[Arxiv](https://arxiv.org/abs/2401.15328)][[Code](https://github.com/adriantheuma/llama2-raven)]
 
 ## Benchmark
+(ShortcutsBench) ShortcutsBench: A Large-Scale Real-World Benchmark for API-Based Agents [[Arxiv](https://arxiv.org/abs/2407.00132)][[Code](https://github.com/eachsheep/shortcutsbench)]
+
 (APIBench) Gorilla: Large Language Model Connected with Massive APIs [[Arxiv](https://arxiv.org/abs/2305.15334)][[Code](https://github.com/ShishirPatil/gorilla)]
 
 API-Bank: A Comprehensive Benchmark for Tool-Augmented LLMs [[EMNLP](https://arxiv.org/abs/2304.08244)][[Code](https://github.com/AlibabaResearch/DAMO-ConvAI/tree/main/api-bank)]


### PR DESCRIPTION
We have added the paper *ShortcutsBench*, published on [arXiv](https://arxiv.org/pdf/2407.00132) in July 2024. 

You can access the dataset, processing code, experimental code, and results through the paper's [repo](https://github.com/eachsheep/shortcutsbench).